### PR TITLE
fix(): adjust query value after selecting an option

### DIFF
--- a/plugin/src/BeautifulMentionsPlugin.tsx
+++ b/plugin/src/BeautifulMentionsPlugin.tsx
@@ -16,7 +16,7 @@ import {
   RangeSelection,
   TextNode,
 } from "lexical";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import * as ReactDOM from "react-dom";
 import { BeautifulMentionsPluginProps } from "./BeautifulMentionsPluginProps";
 import { ComboboxPlugin } from "./ComboboxPlugin";
@@ -128,6 +128,9 @@ export function BeautifulMentionsPlugin(props: BeautifulMentionsPluginProps) {
     onMenuClose,
     punctuation = DEFAULT_PUNCTUATION,
   } = props;
+
+  const justSelectedAnOption = useRef(false);
+
   const isEditorFocused = useIsFocused();
   const triggers = useMemo(
     () => props.triggers || Object.keys(items || {}),
@@ -142,6 +145,7 @@ export function BeautifulMentionsPlugin(props: BeautifulMentionsPluginProps) {
     trigger,
     items,
     onSearch,
+    justSelectedAnOption
   });
   const checkForSlashTriggerMatch = useBasicTypeaheadTriggerMatch("/", {
     minLength: 0,

--- a/plugin/src/BeautifulMentionsPlugin.tsx
+++ b/plugin/src/BeautifulMentionsPlugin.tsx
@@ -245,6 +245,8 @@ export function BeautifulMentionsPlugin(props: BeautifulMentionsPluginProps) {
           nodeToReplace.replace(mentionNode);
         }
         closeMenu?.();
+
+        justSelectedAnOption.current = true;
       });
     },
     [editor, trigger, creatable, mentionEnclosure],

--- a/plugin/src/useMentionLookupService.ts
+++ b/plugin/src/useMentionLookupService.ts
@@ -11,10 +11,11 @@ interface MentionsLookupServiceOptions {
     trigger: string,
     queryString?: string | null,
   ) => Promise<BeautifulMentionsItem[]>;
+  justSelectedAnOption?: React.MutableRefObject<boolean>;
 }
 
 export function useMentionLookupService(options: MentionsLookupServiceOptions) {
-  const { queryString, trigger, searchDelay, items, onSearch } = options;
+  const { queryString, trigger, searchDelay, items, onSearch, justSelectedAnOption } = options;
   const debouncedQueryString = useDebounce(queryString, searchDelay);
   const [loading, setLoading] = useState(false);
   const [results, setResults] = useState<Array<BeautifulMentionsItem>>([]);
@@ -50,12 +51,17 @@ export function useMentionLookupService(options: MentionsLookupServiceOptions) {
     if (onSearch) {
       setLoading(true);
       setQuery(debouncedQueryString);
-      onSearch(trigger, debouncedQueryString)
+      onSearch(trigger, justSelectedAnOption?.current ? '' : debouncedQueryString)
         .then(setResults)
         .finally(() => setLoading(false));
+
+      if (justSelectedAnOption?.current) {
+        justSelectedAnOption.current = false;
+      }
+
       return;
     }
-  }, [debouncedQueryString, items, onSearch, trigger]);
+  }, [debouncedQueryString, items, onSearch, trigger, justSelectedAnOption]);
 
   return useMemo(
     () => ({ loading, results, query }),


### PR DESCRIPTION
This PR aims to fix a strange behavior that I noticed when we are using the `onSearch` method with `searchDelay` to get the suggestions asynchronously. It's a very specific scenario when we type something like `@mat` and then wait for the debounced query to fetch the results. Then when we select an option and quickly type the trigger character again, in this case `@`, seems that is triggering the `onSearch` twice, the first one with the previous query value (`mat`), and then again with the correct empty value. I'll attach a video below to demonstrate.

https://github.com/sodenn/lexical-beautiful-mentions/assets/24362309/ec4bce7a-a811-4525-ae0e-07749b04651e


