### PR TITLE
fix($convertToMentionNodes): triggers followed by text in the middle of a word should be recognized as mentions

### DIFF
--- a/.changeset/wild-moles-heal.md
+++ b/.changeset/wild-moles-heal.md
@@ -1,0 +1,5 @@
+---
+"lexical-beautiful-mentions": patch
+---
+
+fix($convertToMentionNodes): triggers followed by text in the middle of a word should be recognized as mentions

--- a/plugin/src/mention-converter.ts
+++ b/plugin/src/mention-converter.ts
@@ -22,7 +22,8 @@ type Entry = MentionEntry | TextEntry;
 
 function findMentions(text: string, triggers: string[], punctuation: string) {
   const regex = new RegExp(
-    TRIGGERS(triggers) +
+    "(?<=\\s|^|\\()" +
+      TRIGGERS(triggers) +
       "((?:" +
       VALID_CHARS(triggers, punctuation) +
       "){1," +

--- a/plugin/src/mention-utils.spec.ts
+++ b/plugin/src/mention-utils.spec.ts
@@ -3,7 +3,7 @@ import { convertToMentionEntries } from "./mention-converter";
 import { DEFAULT_PUNCTUATION } from "./mention-utils";
 
 describe("mention-utils", () => {
-  it("should get text and mention entries", () => {
+  it("should find mention entries in text", () => {
     const triggers = ["@", "due:", "#"];
     const text = "Hey @john, the task is #urgent and due:tomorrow";
     const entries = convertToMentionEntries(
@@ -42,7 +42,7 @@ describe("mention-utils", () => {
     }
   });
 
-  it("should get text and mention entries with multiple mentions", () => {
+  it("should find multiple mentions with the same trigger", () => {
     const triggers = ["@", "due:", "#"];
     const text = "Hey @john and @jane.";
     const entries = convertToMentionEntries(
@@ -82,5 +82,43 @@ describe("mention-utils", () => {
     );
     expect(entries.length).toBe(1);
     expect(entries[0].type).toBe("text");
+  });
+
+  it("should ignore triggers in the middle of a word", () => {
+    const triggers = ["@"];
+    const text = "test@example.com @hello";
+    const entries = convertToMentionEntries(
+      text,
+      triggers,
+      DEFAULT_PUNCTUATION,
+    );
+    expect(entries.length).toBe(2);
+    expect(entries[0].type).toBe("text");
+    expect(entries[0].value).toBe("test@example.com ");
+    expect(entries[1].type).toBe("mention");
+    if (entries[1].type === "mention") {
+      expect(entries[1].trigger).toBe("@");
+      expect(entries[1].value).toBe("hello");
+    }
+  });
+
+  it("should find mentions in brackets", () => {
+    const triggers = ["@"];
+    const text = "Hey (@john)";
+    const entries = convertToMentionEntries(
+      text,
+      triggers,
+      DEFAULT_PUNCTUATION,
+    );
+    expect(entries.length).toBe(3);
+    expect(entries[0].type).toBe("text");
+    expect(entries[0].value).toBe("Hey (");
+    expect(entries[1].type).toBe("mention");
+    if (entries[1].type === "mention") {
+      expect(entries[1].trigger).toBe("@");
+      expect(entries[1].value).toBe("john");
+    }
+    expect(entries[2].type).toBe("text");
+    expect(entries[2].value).toBe(")");
   });
 });


### PR DESCRIPTION
resolves #322 