### PR TITLE
fix(utils): regex always failed to match if triggers is empty

### DIFF
--- a/plugin/src/mention-utils.ts
+++ b/plugin/src/mention-utils.ts
@@ -52,8 +52,11 @@ export const TRIGGERS = (triggers: string[]) =>
   "(?:" + triggers.join("|") + ")";
 
 // Chars we expect to see in a mention (non-space, non-punctuation).
-export const VALID_CHARS = (triggers: string[], punctuation: string) =>
-  "(?!" + triggers.join("|") + ")[^\\s" + punctuation + "]";
+export const VALID_CHARS = (triggers: string[], punctuation: string) => {
+  const lookahead =
+    triggers.length === 0 ? "" : "(?!" + triggers.join("|") + ")";
+  return lookahead + "[^\\s" + punctuation + "]";
+};
 
 export const LENGTH_LIMIT = 75;
 


### PR DESCRIPTION
**The issue**

In regular expression:

```ts
"(?!" + triggers.join("|") + ")" + "[^\\s" + punctuation + "]"
```

The negative lookahead is `(?!)` if `triggers` is empty, which will always fail to match.

**Changes**

Remove negative lookahead if `triggers` is empty.

This PR fixes #439.
