### PR TITLE
Prevent error with apple pencil when key is undefined

### DIFF
--- a/plugin/src/BeautifulMentionsPlugin.tsx
+++ b/plugin/src/BeautifulMentionsPlugin.tsx
@@ -508,7 +508,7 @@ export function BeautifulMentionsPlugin(props: BeautifulMentionsPluginProps) {
   const handleKeyDown = useCallback(
     (event: KeyboardEvent) => {
       const { key, metaKey, ctrlKey } = event;
-      const simpleKey = key.length === 1;
+      const simpleKey = key?.length === 1;
       const isTrigger = triggers.some((trigger) => key === trigger);
       const wordChar = isWordChar(key, triggers, punctuation);
       if (!simpleKey || (!wordChar && !isTrigger) || metaKey || ctrlKey) {


### PR DESCRIPTION
When scribbling with an apple pencil a keyboard event is sometimes fired with an undefined key causing a 'undefined is not an object' error when checking the key length. This prevents that.