### PR TITLE
feat(): insertMention function use autoSpace of config

### DIFF
--- a/.changeset/stale-seals-explain.md
+++ b/.changeset/stale-seals-explain.md
@@ -1,0 +1,5 @@
+---
+"lexical-beautiful-mentions": patch
+---
+
+feat(): insertMention function use autoSpace of config

--- a/plugin/src/BeautifulMentionsPlugin.tsx
+++ b/plugin/src/BeautifulMentionsPlugin.tsx
@@ -638,6 +638,7 @@ export function BeautifulMentionsPlugin(props: BeautifulMentionsPluginProps) {
             trigger,
             value,
             data,
+            autoSpace
           );
           if (!focus) {
             $setSelection(null);

--- a/plugin/src/BeautifulMentionsPlugin.tsx
+++ b/plugin/src/BeautifulMentionsPlugin.tsx
@@ -680,6 +680,7 @@ export function BeautifulMentionsPlugin(props: BeautifulMentionsPluginProps) {
     editor,
     triggers,
     punctuation,
+    autoSpace,
     allowSpaces,
     insertOnBlur,
     creatable,

--- a/plugin/src/BeautifulMentionsPlugin.tsx
+++ b/plugin/src/BeautifulMentionsPlugin.tsx
@@ -638,7 +638,7 @@ export function BeautifulMentionsPlugin(props: BeautifulMentionsPluginProps) {
             trigger,
             value,
             data,
-            autoSpace
+            autoSpace,
           );
           if (!focus) {
             $setSelection(null);
@@ -670,7 +670,12 @@ export function BeautifulMentionsPlugin(props: BeautifulMentionsPluginProps) {
         OPEN_MENTION_MENU_COMMAND,
         ({ trigger }) => {
           restoreSelection();
-          return $insertTriggerAtSelection(triggers, punctuation, trigger);
+          return $insertTriggerAtSelection(
+            triggers,
+            punctuation,
+            trigger,
+            autoSpace,
+          );
         },
         COMMAND_PRIORITY_LOW,
       ),

--- a/plugin/src/ComboboxPlugin.tsx
+++ b/plugin/src/ComboboxPlugin.tsx
@@ -39,6 +39,7 @@ import { useIsFocused } from "./useIsFocused";
 interface ComboboxPluginProps
   extends Pick<
       BeautifulMentionsPluginProps,
+      | "autoSpace"
       | "comboboxOpen"
       | "onComboboxItemSelect"
       | "comboboxAdditionalItems"
@@ -202,6 +203,7 @@ export function ComboboxPlugin(props: ComboboxPluginProps) {
     onSelectOption,
     triggers,
     punctuation,
+    autoSpace,
     loading,
     triggerFn,
     onQueryChange,
@@ -370,7 +372,12 @@ export function ComboboxPlugin(props: ComboboxPluginProps) {
           nodeToReplace.replace(textNode);
           textNode.select();
         } else {
-          $insertTriggerAtSelection(triggers, punctuation, option.value);
+          $insertTriggerAtSelection(
+            triggers,
+            punctuation,
+            option.value,
+            autoSpace,
+          );
         }
       });
       setTriggerMatch(null);
@@ -385,6 +392,7 @@ export function ComboboxPlugin(props: ComboboxPluginProps) {
       triggerMatch,
       triggers,
       punctuation,
+      autoSpace,
     ],
   );
 

--- a/plugin/src/mention-commands.ts
+++ b/plugin/src/mention-commands.ts
@@ -123,8 +123,9 @@ export function $insertMentionAtSelection(
   trigger: string,
   value: string,
   data?: { [key: string]: BeautifulMentionsItemData },
+  autoSpace?: boolean,
 ) {
-  return $insertMentionOrTrigger(triggers, punctuation, trigger, value, data);
+  return $insertMentionOrTrigger(triggers, punctuation, trigger, value, data, autoSpace);
 }
 
 function $insertMentionOrTrigger(
@@ -133,6 +134,7 @@ function $insertMentionOrTrigger(
   trigger: string,
   value?: string,
   data?: { [key: string]: BeautifulMentionsItemData },
+  autoSpace?: boolean,
 ) {
   const selectionInfo = $getSelectionInfo(triggers, punctuation);
   if (!selectionInfo) {
@@ -155,24 +157,28 @@ function $insertMentionOrTrigger(
     ? $createBeautifulMentionNode(trigger, value, data)
     : $createTextNode(trigger);
 
+  const nodes: LexicalNode[] = [];
   // Insert a mention with a leading space
   if (!($isParagraphNode(node) && cursorAtStartOfNode) && !$isTextNode(node)) {
-    selection.insertNodes([$createTextNode(" "), mentionNode]);
+    if (autoSpace) nodes.push($createTextNode(" "))
+    nodes.push(mentionNode)
+    selection.insertNodes(nodes);
     return true;
   }
 
   let spaceNode: TextNode | null = null;
-  const nodes: LexicalNode[] = [];
   if (
+    autoSpace && (
     wordCharBeforeCursor ||
-    (cursorAtStartOfNode && prevNode !== null && !$isTextNode(prevNode))
+    (cursorAtStartOfNode && prevNode !== null && !$isTextNode(prevNode)))
   ) {
     nodes.push($createTextNode(" "));
   }
   nodes.push(mentionNode);
   if (
+    autoSpace && (
     wordCharAfterCursor ||
-    (cursorAtEndOfNode && nextNode !== null && !$isTextNode(nextNode))
+    (cursorAtEndOfNode && nextNode !== null && !$isTextNode(nextNode)))
   ) {
     spaceNode = $createTextNode(" ");
     nodes.push(spaceNode);

--- a/plugin/src/mention-commands.ts
+++ b/plugin/src/mention-commands.ts
@@ -113,8 +113,16 @@ export function $insertTriggerAtSelection(
   triggers: string[],
   punctuation: string,
   trigger: string,
+  autoSpace?: boolean,
 ) {
-  return $insertMentionOrTrigger(triggers, punctuation, trigger);
+  return $insertMentionOrTrigger(
+    triggers,
+    punctuation,
+    trigger,
+    undefined,
+    undefined,
+    autoSpace,
+  );
 }
 
 export function $insertMentionAtSelection(
@@ -125,7 +133,14 @@ export function $insertMentionAtSelection(
   data?: { [key: string]: BeautifulMentionsItemData },
   autoSpace?: boolean,
 ) {
-  return $insertMentionOrTrigger(triggers, punctuation, trigger, value, data, autoSpace);
+  return $insertMentionOrTrigger(
+    triggers,
+    punctuation,
+    trigger,
+    value,
+    data,
+    autoSpace,
+  );
 }
 
 function $insertMentionOrTrigger(
@@ -160,25 +175,27 @@ function $insertMentionOrTrigger(
   const nodes: LexicalNode[] = [];
   // Insert a mention with a leading space
   if (!($isParagraphNode(node) && cursorAtStartOfNode) && !$isTextNode(node)) {
-    if (autoSpace) nodes.push($createTextNode(" "))
-    nodes.push(mentionNode)
+    if (autoSpace) {
+      nodes.push($createTextNode(" "));
+    }
+    nodes.push(mentionNode);
     selection.insertNodes(nodes);
     return true;
   }
 
   let spaceNode: TextNode | null = null;
   if (
-    autoSpace && (
-    wordCharBeforeCursor ||
-    (cursorAtStartOfNode && prevNode !== null && !$isTextNode(prevNode)))
+    autoSpace &&
+    (wordCharBeforeCursor ||
+      (cursorAtStartOfNode && prevNode !== null && !$isTextNode(prevNode)))
   ) {
     nodes.push($createTextNode(" "));
   }
   nodes.push(mentionNode);
   if (
-    autoSpace && (
-    wordCharAfterCursor ||
-    (cursorAtEndOfNode && nextNode !== null && !$isTextNode(nextNode)))
+    autoSpace &&
+    (wordCharAfterCursor ||
+      (cursorAtEndOfNode && nextNode !== null && !$isTextNode(nextNode)))
   ) {
     spaceNode = $createTextNode(" ");
     nodes.push(spaceNode);


### PR DESCRIPTION
Open a new PR, the old one is https://github.com/sodenn/lexical-beautiful-mentions/pull/691#issue-2601159954

function `insertMention` use `autoSpace` config of plugin

before: 

https://github.com/user-attachments/assets/c07a0d4e-58b4-4a56-b183-38d4c2bd75cd

after:

https://github.com/user-attachments/assets/52fbd76e-b4a7-41cd-8b51-b626890b857c

Please check with other modules to see if it's feasible. I haven't fully familiarized myself with all the logic of this project yet.

