### PR TITLE
Prevent error with Apple Pencil when key is undefined

### DIFF
--- a/.changeset/metal-knives-exist.md
+++ b/.changeset/metal-knives-exist.md
@@ -1,0 +1,5 @@
+---
+"lexical-beautiful-mentions": patch
+---
+
+fix: prevent error with Apple Pencil when key is undefined

--- a/plugin/src/BeautifulMentionsPlugin.tsx
+++ b/plugin/src/BeautifulMentionsPlugin.tsx
@@ -545,7 +545,7 @@ export function BeautifulMentionsPlugin(props: BeautifulMentionsPluginProps) {
   const handleKeyDown = useCallback(
     (event: KeyboardEvent) => {
       const { key, metaKey, ctrlKey } = event;
-      const simpleKey = key.length === 1;
+      const simpleKey = key?.length === 1; // key is undefined for Apple Pencil keyboard events
       const wordChar = isWordChar(key, triggers, punctuation);
       const isSpace = allowSpaces && /^\s$/.test(key);
       if (!simpleKey || metaKey || ctrlKey) {

--- a/plugin/src/BeautifulMentionsPlugin.tsx
+++ b/plugin/src/BeautifulMentionsPlugin.tsx
@@ -545,6 +545,7 @@ export function BeautifulMentionsPlugin(props: BeautifulMentionsPluginProps) {
   const handleKeyDown = useCallback(
     (event: KeyboardEvent) => {
       const { key, metaKey, ctrlKey } = event;
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       const simpleKey = key?.length === 1; // key is undefined for Apple Pencil keyboard events
       const wordChar = isWordChar(key, triggers, punctuation);
       const isSpace = allowSpaces && /^\s$/.test(key);


### PR DESCRIPTION
When scribbling with an Apple Pencil a keyboard event is sometimes fired with an undefined key causing a 'undefined is not an object' error when checking the key length. This prevents that. Same fix as #575