### PR TITLE
docs(README): describe trigger-specific `creatable`

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,16 @@ Hide the menu item that allows users to create new mentions:
 />
 ```
 
+Hide the menu item that allows users to create new mentions for specific triggers, while enabling it for other triggers:
+
+```tsx
+
+<BeautifulMentionsPlugin
+  items={mentionItems}
+  creatable={{ "@": `Add user "{{name}}"`, "#": false }} // 👈 allow creating "@" mentions but not "#" mentions
+/>
+```
+
 ### Async query function
 
 ```tsx


### PR DESCRIPTION
Describe the trigger-specific options for `creatable`, where users of the library can enable creatable options for certain triggers while disabling it for other triggers.