### PR TITLE
fix(createMentionNode): Add 'withKlass' to lexical node replacement

### DIFF
--- a/.changeset/swift-points-clap.md
+++ b/.changeset/swift-points-clap.md
@@ -1,0 +1,5 @@
+---
+"lexical-beautiful-mentions": patch
+---
+
+fix(createMentionNode): Add 'withKlass' to lexical node replacement

--- a/plugin/src/createMentionNode.ts
+++ b/plugin/src/createMentionNode.ts
@@ -38,6 +38,7 @@ export function createBeautifulMentionNode(
           node.getData(),
         );
       },
+      withKlass: CustomBeautifulMentionNode
     },
   ];
 }


### PR DESCRIPTION
Lexical is issuing a console warning that 'withKlass' will be required when replacing nodes in a future version.
This PR adds that change to future-proof the custom mention node feature.

Lexical warning:
<img width="540" height="47" alt="Screenshot 2025-08-06 at 2 24 46 PM" src="https://github.com/user-attachments/assets/cbb20598-eb7d-44b1-976e-ec3a8da1ee25" />

warning comes from lexical code [HERE](https://github.com/facebook/lexical/blob/abd71301c6fa1b9cd6c4b665b47313a32db36889/packages/lexical/src/LexicalEditor.ts#L563)