### PR TITLE
Improve return type of createBeautifulMentionNode.

### DIFF
--- a/plugin/src/createMentionNode.ts
+++ b/plugin/src/createMentionNode.ts
@@ -7,7 +7,7 @@ import {
   SerializedBeautifulMentionNode,
 } from "./MentionNode";
 
-export type CustomBeautifulMentionNodeClass = ReturnType<typeof generateClass>;
+export type CustomBeautifulMentionNodeClass = typeof BeautifulMentionNode;
 
 export let CustomBeautifulMentionNode: CustomBeautifulMentionNodeClass;
 


### PR DESCRIPTION
The former ReturnType<typeof generateClass> extracts all properties of the returned class type statically at build time of lexical-beautiful-mentions package. This includes internal LexicalNode properties, that might change with lexical updates. The class returned by generateClass extends BeautifulMentionsNode, so using that as return type is fine, because its type will inherit all properties from the used lexical version.