### PR TITLE
fix(environment): prevent top-level errors in non-standard environments

### DIFF
--- a/plugin/src/environment.ts
+++ b/plugin/src/environment.ts
@@ -10,4 +10,4 @@ export const IS_IOS: boolean =
   !window.MSStream;
 
 export const IS_MOBILE =
-  CAN_USE_DOM && window.matchMedia("(pointer: coarse)").matches;
+  CAN_USE_DOM && typeof window.matchMedia === "function" && window.matchMedia("(pointer: coarse)").matches;


### PR DESCRIPTION
Adds a check to ensure that `window.matchMedia` is available before using it in `environment.ts` to prevent top-level errors in environments where it is not available (such as tests).